### PR TITLE
fix: permit /actuator/health/** + bump to 0.1.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Trusta MSA 프로젝트의 **공통 라이브러리**. 모든 도메인 서비스에서 의존성으로 추가해 사용한다.
 
 - **패키지 베이스**: `com.trustamarket.common`
-- **Artifact**: `com.trustamarket:common:0.0.1-SNAPSHOT`
+- **Artifact**: `com.trustamarket:common:0.1.0-SNAPSHOT`
 - **배포**: GitHub Packages (`trusta-market/common`)
 - **Java**: 21 / **Spring Boot**: 3.5.13 / **Spring Cloud**: 2025.0.1
 
@@ -309,7 +309,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.trustamarket:common:0.0.1-SNAPSHOT'
+    implementation 'com.trustamarket:common:0.1.0-SNAPSHOT'
 }
 ```
 
@@ -793,8 +793,9 @@ public interface ProductClient {
 **deny by default** — `anyRequest().authenticated()` 가 기본값. 공유 모듈이 모든 소비 서비스에 안전한 기본값을 깔아둔다.
 
 예외로 permitAll:
-- `/actuator/health`
+- `/actuator/health`, `/actuator/health/**` (K8s liveness/readiness probe)
 - `/actuator/info`
+- `/actuator/prometheus` (Prometheus scrape)
 
 소비 서비스에 **public 엔드포인트**가 필요하면 자체 `SecurityFilterChain` 을 `@Bean`으로 등록해 override.
 
@@ -900,6 +901,9 @@ public class SomeService {
 - [ ] Liquibase 도입 검토 (ddl-auto → Liquibase)
 - [ ] Security Role 이름 Trusta 정책 확정 후 재검토
 - [ ] 인증 정책 확정 후 LoginFilter `trust-gateway-headers` 기본값 재검토 (HMAC 서명 방식 등)
+
+### 완료 (v0.1.0-SNAPSHOT)
+- [x] `SecurityConfig` permitAll 확장 — `/actuator/health/**` 와일드카드 + `/actuator/prometheus` (K8s probe + Prometheus scrape 호환)
 
 ### 완료 (v0.0.1-SNAPSHOT)
 - [x] `WebConfig` RestrictedPageableResolver 체인 앞 등록

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.trustamarket'
-version = '0.0.1-SNAPSHOT'
+version = '0.1.0-SNAPSHOT'
 
 java {
 	toolchain {

--- a/src/main/java/com/trustamarket/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/trustamarket/common/config/security/SecurityConfig.java
@@ -34,7 +34,9 @@ public class SecurityConfig {
                 // deny by default — actuator health/info 외 모든 요청은 인증 필수.
                 // 소비 서비스의 public 엔드포인트(/signup, /login 등)는 각자 SecurityConfig 에서 override.
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                        // K8s probe (liveness/readiness) 와 Prometheus scrape 가 인증 없이 접근.
+                        // /actuator/health/** 와일드카드로 /actuator/health/liveness, /readiness 등 포함.
+                        .requestMatchers("/actuator/health/**", "/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(c -> {


### PR DESCRIPTION
## 🌱 설명

K8s 환경에서 사용 위해 actuator 경로 보안 정책 확장 + minor version up.

도메인 서비스를 GKE 에 배포 후 K8s liveness/readiness probe (`/actuator/health/liveness`, `/actuator/health/readiness`) 가 common 의 SecurityConfig 의 `anyRequest().authenticated()` 에 걸려 401 → Pod CrashLoopBackOff 발생. 와일드카드 추가로 해결.

## 📌 관련 이슈

해당 없음 (인프라 셋업, 이슈 생략)

## ✅ 주요 변경 사항

- `SecurityConfig` — `requestMatchers` permitAll 항목 확장
  - `/actuator/health/**` 와일드카드 추가 (K8s liveness/readiness probe 호환)
  - `/actuator/prometheus` 추가 (Prometheus scrape 호환)
- `build.gradle` — version `0.0.1-SNAPSHOT` → **`0.1.0-SNAPSHOT`**
- `README.md` — Artifact / dependency 예시 / Security 정책 / TODO 섹션 업데이트

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요? *(인프라 셋업이라 이슈 생략)*
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요? (`./gradlew compileJava` BUILD SUCCESSFUL)

## 🔧 머지 후 작업

PR 머지 후 develop 에서 GitHub Packages 에 publish:

```bash
cd ~/sparta/trusta/common
git checkout develop && git pull
./gradlew clean build publish
```

publish 끝나면 `0.1.0-SNAPSHOT` 이 GitHub Packages 에 등록됨.

## 📚 영향 받는 서비스 (7개)

`com.trustamarket:common:0.0.1-SNAPSHOT` 의존하던 서비스들의 `build.gradle` 도 `0.1.0-SNAPSHOT` 로 같이 업데이트 (별도 PR 또는 각 서비스 다음 배포 시점에 함께):

- user-service / product-service / order-service / payment-service
- wallet-service / delivery-service / notification-service

각 서비스 재배포 시 자동으로 새 common 가져옴. 기존 떠있는 Pod (api-gateway 등 — common 의존 X) 영향 0.

## 📊 변경 영향 분석

| 변경 | 영향 |
|---|---|
| permitAll 와일드카드 확장 | `/actuator/health/*` 가 인증 없이 접근 가능. K8s cluster 내부에서만 호출되니 외부 노출 없음 |
| version bump | SNAPSHOT 이라 같은 버전 덮어쓰기 가능. 소비 서비스는 `--refresh-dependencies` 또는 다음 빌드 시 자동 fetch |
| 기존 actuator 보호 항목 (env, beans, configprops 등) | 그대로 인증 요구 (변경 X) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated version references to 0.1.0-SNAPSHOT in library dependencies and project configuration.

* **Security**
  * Extended unauthenticated access to monitoring endpoints, including health checks (with wildcard pattern) and Prometheus metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/common/pull/3)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->