### PR TITLE
fix: TaskDecorator 가 RequestContext / SecurityContext 도 전파

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.trustamarket'
-version = '0.1.0-SNAPSHOT'
+version = '0.2.0-SNAPSHOT'
 
 java {
 	toolchain {

--- a/src/main/java/com/trustamarket/common/config/feign/FeignConfig.java
+++ b/src/main/java/com/trustamarket/common/config/feign/FeignConfig.java
@@ -1,5 +1,6 @@
 package com.trustamarket.common.config.feign;
 
+import com.trustamarket.common.util.HeaderSnapshotHolder;
 import feign.RequestInterceptor;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.cloud.openfeign.EnableFeignClients;
@@ -8,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import java.util.List;
+import java.util.Map;
 
 // Feign 공통 설정. com.trustamarket 하위 @FeignClient 자동 스캔.
 // 현재 요청의 인증/추적 헤더를 아웃바운드 호출에 자동 전파한다.
@@ -17,29 +18,26 @@ import java.util.List;
 @EnableFeignClients(basePackages = "com.trustamarket")
 public class FeignConfig {
 
-    // 아웃바운드 Feign 요청으로 복사할 헤더. 헤더 추가 시 이 목록만 수정.
-    private static final List<String> PROPAGATE_HEADERS = List.of(
-            "Authorization",
-            "X-User-UUID",
-            "X-User-Email",
-            "X-User-Name",
-            "X-User-Role",
-            "X-User-Slack-Id",
-            "X-User-Enabled",
-            "X-Trace-Id"
-    );
-
-    // 현재 HTTP 요청의 헤더를 Feign 템플릿에 복사.
-    // 비동기/스케줄러 컨텍스트에는 RequestAttributes 가 없어 조용히 skip 된다.
+    // 헤더 전파 우선순위:
+    // 1. HeaderSnapshotHolder (async thread — MdcTaskDecorator 가 미리 캡처해 둔 snapshot)
+    // 2. RequestContextHolder (동기 thread — 원본 HttpServletRequest)
+    //
+    // 전파 대상 헤더 목록은 HeaderSnapshotHolder.PROPAGATE_HEADERS 에 중앙화 (헤더 추가 시 한 곳만 수정).
     @Bean
     public RequestInterceptor requestHeaderInterceptor() {
         return template -> {
+            Map<String, String> snapshot = HeaderSnapshotHolder.get();
+            if (snapshot != null) {
+                snapshot.forEach(template::header);
+                return;
+            }
+
             ServletRequestAttributes attributes =
                     (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
             if (attributes == null) return;
 
             HttpServletRequest request = attributes.getRequest();
-            for (String header : PROPAGATE_HEADERS) {
+            for (String header : HeaderSnapshotHolder.PROPAGATE_HEADERS) {
                 String value = request.getHeader(header);
                 if (value != null) {
                     template.header(header, value);

--- a/src/main/java/com/trustamarket/common/util/HeaderSnapshotHolder.java
+++ b/src/main/java/com/trustamarket/common/util/HeaderSnapshotHolder.java
@@ -1,0 +1,45 @@
+package com.trustamarket.common.util;
+
+import java.util.List;
+import java.util.Map;
+
+// async thread 에서 X-User-* 헤더 등을 안전히 전파하기 위한 snapshot holder.
+//
+// 원본 HttpServletRequest 는 요청 종료 후 컨테이너가 회수 → 자식 thread 에서 접근 시
+// IllegalStateException ("request is not active anymore") 발생 가능.
+// 미리 헤더 값을 캡처해서 별도 ThreadLocal 에 박아 두면 라이프사이클과 독립적으로 안전하게 읽음.
+//
+// 책임 분담:
+// - MdcTaskDecorator: 부모 thread 의 헤더 → snapshot 캡처 → 자식 thread 에 set, 종료 시 clear
+// - FeignConfig.requestHeaderInterceptor: snapshot 있으면 그것 사용, 없으면 RequestContextHolder fallback
+public final class HeaderSnapshotHolder {
+
+    // FeignConfig 와 MdcTaskDecorator 가 공통 참조 — 헤더 추가/제거 시 이 한 곳만 수정.
+    public static final List<String> PROPAGATE_HEADERS = List.of(
+            "Authorization",
+            "X-User-UUID",
+            "X-User-Email",
+            "X-User-Name",
+            "X-User-Role",
+            "X-User-Slack-Id",
+            "X-User-Enabled",
+            "X-Trace-Id"
+    );
+
+    private static final ThreadLocal<Map<String, String>> HOLDER = new ThreadLocal<>();
+
+    private HeaderSnapshotHolder() {
+    }
+
+    public static void set(Map<String, String> snapshot) {
+        HOLDER.set(snapshot);
+    }
+
+    public static Map<String, String> get() {
+        return HOLDER.get();
+    }
+
+    public static void clear() {
+        HOLDER.remove();
+    }
+}

--- a/src/main/java/com/trustamarket/common/util/MdcTaskDecorator.java
+++ b/src/main/java/com/trustamarket/common/util/MdcTaskDecorator.java
@@ -2,24 +2,44 @@ package com.trustamarket.common.util;
 
 import org.slf4j.MDC;
 import org.springframework.core.task.TaskDecorator;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
 
 import java.util.Map;
 
-// @Async 스레드에 부모 스레드의 MDC(traceId 등)를 전파하는 TaskDecorator.
-// EventConfig 의 ThreadPool 에 설정되어 비동기 로그에도 traceId 가 유지된다.
+// @Async / @TransactionalEventListener 스레드에 부모 스레드의 컨텍스트를 전파한다.
+//
+// 전파 대상:
+// - MDC (X-Trace-Id 등)            — 비동기 로그에도 traceId 유지
+// - RequestAttributes (HTTP 요청)   — FeignConfig 가 X-User-* 헤더 전파에 사용
+//                                     (RequestContextHolder 는 ThreadLocal 기반이라 async 면 null)
+// - SecurityContext                — @PreAuthorize 등 권한 검사가 async 흐름에서도 동작
+//
+// EventConfig.taskExecutor 에 설정되어 적용된다. 이름은 호환 유지 — 내부적으로 컨텍스트 3종 전파.
 public class MdcTaskDecorator implements TaskDecorator {
 
     @Override
     public Runnable decorate(Runnable runnable) {
         Map<String, String> contextMap = MDC.getCopyOfContextMap();
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+
         return () -> {
             try {
                 if (contextMap != null) {
                     MDC.setContextMap(contextMap);
                 }
+                if (requestAttributes != null) {
+                    RequestContextHolder.setRequestAttributes(requestAttributes);
+                }
+                SecurityContextHolder.setContext(securityContext);
                 runnable.run();
             } finally {
                 MDC.clear();
+                RequestContextHolder.resetRequestAttributes();
+                SecurityContextHolder.clearContext();
             }
         };
     }

--- a/src/main/java/com/trustamarket/common/util/MdcTaskDecorator.java
+++ b/src/main/java/com/trustamarket/common/util/MdcTaskDecorator.java
@@ -1,46 +1,80 @@
 package com.trustamarket.common.util;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.MDC;
 import org.springframework.core.task.TaskDecorator;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.util.HashMap;
 import java.util.Map;
 
 // @Async / @TransactionalEventListener 스레드에 부모 스레드의 컨텍스트를 전파한다.
 //
 // 전파 대상:
-// - MDC (X-Trace-Id 등)            — 비동기 로그에도 traceId 유지
-// - RequestAttributes (HTTP 요청)   — FeignConfig 가 X-User-* 헤더 전파에 사용
-//                                     (RequestContextHolder 는 ThreadLocal 기반이라 async 면 null)
-// - SecurityContext                — @PreAuthorize 등 권한 검사가 async 흐름에서도 동작
+// - MDC (X-Trace-Id 등)           — 비동기 로그에도 traceId 유지
+// - 헤더 snapshot (X-User-* 등)   — FeignConfig 가 async 흐름에서도 헤더 전파
+//                                    HttpServletRequest 참조 직접 전달 시 라이프사이클 종료 후
+//                                    IllegalStateException 위험 → snapshot Map 으로 캡처
+// - SecurityContext (복사본)      — @PreAuthorize 등 권한 검사 동작
+//                                    참조 공유 시 부모/자식 race condition → createEmptyContext 로 복사
 //
-// EventConfig.taskExecutor 에 설정되어 적용된다. 이름은 호환 유지 — 내부적으로 컨텍스트 3종 전파.
+// EventConfig.taskExecutor 에 설정되어 적용된다.
 public class MdcTaskDecorator implements TaskDecorator {
 
     @Override
     public Runnable decorate(Runnable runnable) {
         Map<String, String> contextMap = MDC.getCopyOfContextMap();
-        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-        SecurityContext securityContext = SecurityContextHolder.getContext();
+        Map<String, String> headerSnapshot = captureHeaderSnapshot();
+        SecurityContext securityContextCopy = copySecurityContext();
 
         return () -> {
             try {
                 if (contextMap != null) {
                     MDC.setContextMap(contextMap);
                 }
-                if (requestAttributes != null) {
-                    RequestContextHolder.setRequestAttributes(requestAttributes);
+                if (headerSnapshot != null) {
+                    HeaderSnapshotHolder.set(headerSnapshot);
                 }
-                SecurityContextHolder.setContext(securityContext);
+                SecurityContextHolder.setContext(securityContextCopy);
                 runnable.run();
             } finally {
                 MDC.clear();
-                RequestContextHolder.resetRequestAttributes();
+                HeaderSnapshotHolder.clear();
                 SecurityContextHolder.clearContext();
             }
         };
+    }
+
+    // 부모 thread 의 HttpServletRequest 에서 전파 대상 헤더만 추출.
+    // RequestContextHolder 가 ServletRequestAttributes 가 아니면 (e.g. 스케줄러) null 반환.
+    private Map<String, String> captureHeaderSnapshot() {
+        if (!(RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes attrs)) {
+            return null;
+        }
+        HttpServletRequest request = attrs.getRequest();
+        Map<String, String> snapshot = new HashMap<>(HeaderSnapshotHolder.PROPAGATE_HEADERS.size() * 2);
+        for (String header : HeaderSnapshotHolder.PROPAGATE_HEADERS) {
+            String value = request.getHeader(header);
+            if (value != null) {
+                snapshot.put(header, value);
+            }
+        }
+        return snapshot;
+    }
+
+    // SecurityContext 를 새로 만들어 Authentication 만 복사. 참조 공유로 인한 race condition 방지.
+    // Spring 의 DelegatingSecurityContextRunnable 과 동일 패턴.
+    private SecurityContext copySecurityContext() {
+        SecurityContext original = SecurityContextHolder.getContext();
+        SecurityContext copy = SecurityContextHolder.createEmptyContext();
+        Authentication auth = original.getAuthentication();
+        if (auth != null) {
+            copy.setAuthentication(auth);
+        }
+        return copy;
     }
 }


### PR DESCRIPTION
## 🌱 설명

#4 의 근본 fix. 기존 `MdcTaskDecorator` 는 MDC 만 전파해서 async thread 에서 ThreadLocal 컨텍스트 (RequestAttributes / SecurityContext) 유실 → FeignConfig 의 X-User-* 헤더 전파 실패 → 받는 service 401.

## 📌 관련 이슈

close #4

## ✅ 주요 변경 사항

- `MdcTaskDecorator` 확장: MDC + RequestAttributes + SecurityContext 동시 전파
- `EventConfig.taskExecutor` 가 이미 이 decorator 사용 중이라 자동 적용 (다른 코드 변경 없음)
- `build.gradle` version `0.1.0-SNAPSHOT` → `0.2.0-SNAPSHOT`

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- 머지 후 GitHub Packages 에 수동 publish 필요 (workflow 없음): `./gradlew publish -Pgpr.user=<id> -Pgpr.token=<PAT>`
- 그 후 8개 도메인 서비스 (wallet/payment/order/product/delivery/inspection/notification/user) 의 build.gradle 의 common 버전을 `0.2.0-SNAPSHOT` 으로 갱신 + 재배포 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project version to 0.2.0-SNAPSHOT

* **Improvements**
  * Enhanced async task execution to properly maintain logging and security context information across background operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/common/pull/5)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->