### PR TITLE
fix(advice): /actuator/** + byte[] / Resource 반환 wrap 제외 (0.3.0-SNAPSHOT)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.trustamarket'
-version = '0.2.0-SNAPSHOT'
+version = '0.3.0-SNAPSHOT'
 
 java {
 	toolchain {

--- a/src/main/java/com/trustamarket/common/response/CommonResponseAdvice.java
+++ b/src/main/java/com/trustamarket/common/response/CommonResponseAdvice.java
@@ -2,12 +2,14 @@ package com.trustamarket.common.response;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.core.ResolvableType;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
@@ -16,7 +18,8 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
 // 컨트롤러 반환값을 CommonResponse / PagedResponse / SlicedResponse 로 자동 래핑하는 Advice.
 // @RestControllerAdvice 로 Spring 이 ResponseBodyAdvice 로 자동 인식하도록 한다 (@Bean 등록만으론 부족).
-// String 반환은 제외(컨버터 이슈), 이미 래핑된 응답은 통과.
+// String / byte[] / Resource 반환은 제외(컨버터 이슈) — 특히 actuator/prometheus 가 byte[] 라 wrap 시 ClassCastException.
+// 이미 래핑된 응답은 통과. /actuator/** path 는 path 기반으로도 통과 (framework 응답 형식 보존).
 // Page<?> → PagedResponse, Slice<?> (Page 아닌) → SlicedResponse, 그 외 → CommonResponse.
 @RestControllerAdvice
 public class CommonResponseAdvice implements ResponseBodyAdvice<Object> {
@@ -24,13 +27,14 @@ public class CommonResponseAdvice implements ResponseBodyAdvice<Object> {
     @Override
     public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
         Class<?> paramType = returnType.getParameterType();
-        // ResponseEntity<String> / HttpEntity<String> 도 String 으로 간주 — StringHttpMessageConverter 가 선택되므로 wrap 하면 변환 실패.
-        if (String.class.equals(paramType)) {
+        // String / byte[] / Resource: 각자 전용 HttpMessageConverter 가 선택되므로 wrap 하면 변환 실패.
+        if (isExcludedType(paramType)) {
             return false;
         }
+        // ResponseEntity<String> / HttpEntity<byte[]> 등 generic 도 동일.
         if (HttpEntity.class.isAssignableFrom(paramType)) {
             Class<?> generic = ResolvableType.forMethodParameter(returnType).getGeneric(0).resolve();
-            if (generic != null && String.class.equals(generic)) {
+            if (generic != null && isExcludedType(generic)) {
                 return false;
             }
         }
@@ -40,6 +44,12 @@ public class CommonResponseAdvice implements ResponseBodyAdvice<Object> {
                 && !paramType.equals(ErrorResponse.class);
     }
 
+    private static boolean isExcludedType(Class<?> type) {
+        return String.class.equals(type)
+                || byte[].class.equals(type)
+                || Resource.class.isAssignableFrom(type);
+    }
+
     @Override
     public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
                                   Class<? extends HttpMessageConverter<?>> selectedConverterType,
@@ -47,6 +57,15 @@ public class CommonResponseAdvice implements ResponseBodyAdvice<Object> {
         // null body 는 래핑 금지 — HTTP 204/304 zero-byte 응답 계약을 깨지 않도록.
         if (body == null) {
             return null;
+        }
+
+        // actuator endpoint (/actuator/health, /actuator/prometheus 등) 는 wrap 안 함.
+        // Spring Boot framework 가 정의한 응답 형식 (health JSON / prometheus text/plain) 보존.
+        if (request instanceof ServletServerHttpRequest servletReq) {
+            String path = servletReq.getServletRequest().getRequestURI();
+            if (path != null && path.startsWith("/actuator/")) {
+                return body;
+            }
         }
 
         int status = resolveStatus(response);


### PR DESCRIPTION
## 🌱 설명

CommonResponseAdvice 가 `/actuator/prometheus` (byte[] 반환) 도 `CommonResponse` 로 wrap 시도 → `ClassCastException` → 500. GMP collector 가 메트릭 scrape 못 함 → 부하 테스트 시 메트릭 측정 불가.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

- `supports()`: String 외에 `byte[]` / `Resource` 도 wrap 제외 (각자 전용 HttpMessageConverter 가 처리)
- `HttpEntity<T>` generic 도 동일 적용 (`ResponseEntity<byte[]>` 등)
- `beforeBodyWrite()`: request URI `/actuator/` 시작이면 통과 (framework 응답 형식 보존)
- version: `0.2.0-SNAPSHOT` → `0.3.0-SNAPSHOT`

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

머지 후 각 service 의 build.gradle 의 common version 0.3.0-SNAPSHOT 으로 bump 필요 (10개 service). 그래야 actuator/prometheus 정상 응답 → GMP 메트릭 수집 가능.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.3.0-SNAPSHOT

* **Bug Fixes**
  * Corrected response handling for Spring Boot actuator endpoints (health, metrics) to preserve native response formatting
  * Enhanced response type filtering for improved compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/common/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->