### PR TITLE
feat: common 에 springdoc auto-config 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.trustamarket'
-version = '0.3.0-SNAPSHOT'
+version = '0.4.0-SNAPSHOT'
 
 java {
 	toolchain {
@@ -36,6 +36,10 @@ dependencies {
 	api 'org.springframework.boot:spring-boot-starter-security'
 	api 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	// spring-kafka: common 에서 직접 사용 X. Kafka 가 필요한 도메인 서비스가 직접 추가.
+
+	// Swagger / OpenAPI — SwaggerConfig 가 ConditionalOnClass 로 자동 활성화.
+	// servlet (MVC) 기반. api-gateway (WebFlux) 는 별도 webflux-ui 사용.
+	api 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	// QueryDSL
 	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'

--- a/src/main/java/com/trustamarket/common/config/CommonAutoConfiguration.java
+++ b/src/main/java/com/trustamarket/common/config/CommonAutoConfiguration.java
@@ -33,7 +33,8 @@ import org.springframework.web.servlet.HandlerExceptionResolver;
         EventConfig.class,
         FeignConfig.class,
         WebConfig.class,
-        SecurityConfig.class
+        SecurityConfig.class,
+        SwaggerConfig.class
 })
 public class CommonAutoConfiguration {
 

--- a/src/main/java/com/trustamarket/common/config/SwaggerConfig.java
+++ b/src/main/java/com/trustamarket/common/config/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package com.trustamarket.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+// Springdoc 의존성이 있을 때만 자동 활성화. OpenAPI 메타 + Keycloak JWT Bearer SecurityScheme 등록.
+// 각 서비스가 자체 OpenAPI 빈을 등록하면 그쪽이 우선 (ConditionalOnMissingBean).
+@Configuration
+@ConditionalOnClass(name = "io.swagger.v3.oas.models.OpenAPI")
+public class SwaggerConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "BearerAuth";
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OpenAPI trustaOpenAPI(@Value("${spring.application.name:trusta-service}") String appName) {
+        return new OpenAPI()
+                .info(new Info()
+                        .title(appName + " API")
+                        .version("v1")
+                        .description("Trusta Market — " + appName))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("Keycloak JWT access_token")));
+    }
+}

--- a/src/main/java/com/trustamarket/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/trustamarket/common/config/security/SecurityConfig.java
@@ -37,6 +37,10 @@ public class SecurityConfig {
                         // K8s probe (liveness/readiness) 와 Prometheus scrape 가 인증 없이 접근.
                         // /actuator/health/** 와일드카드로 /actuator/health/liveness, /readiness 등 포함.
                         .requestMatchers("/actuator/health/**", "/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
+                        // Swagger / OpenAPI — 외부 노출은 api-gateway 에서 ADMIN role 로 보호.
+                        // 각 서비스의 /v3/api-docs/** 는 api-gateway 가 cluster 내부에서 fetch (aggregation).
+                        // /swagger-ui/** 는 서비스 직접 접근 시 dev 디버깅 용도.
+                        .requestMatchers("/v3/api-docs/**", "/v3/api-docs.yaml", "/swagger-ui/**", "/swagger-ui.html", "/swagger-resources/**", "/webjars/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(c -> {

--- a/src/main/java/com/trustamarket/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/trustamarket/common/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.trustamarket.common.config.security;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -25,24 +26,34 @@ public class SecurityConfig {
     private final CustomAccessDeniedHandler accessDeniedHandler;
 
     // CSRF off (REST API), stateless 세션, LoginFilter 앞에 배치, 401/403 은 ErrorResponse JSON.
+    // Swagger 경로 permit 은 trusta.swagger.expose-public=true 일 때만 — 라이브러리 default 는 닫혀있음.
+    // 소비 서비스가 application.yaml 에 명시적으로 opt-in 해야 활성화 (외부 직접 노출 방지).
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(
+            HttpSecurity http,
+            @Value("${trusta.swagger.expose-public:false}") boolean exposeSwaggerPublic
+    ) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(loginFilter, UsernamePasswordAuthenticationFilter.class)
                 // deny by default — actuator health/info 외 모든 요청은 인증 필수.
                 // 소비 서비스의 public 엔드포인트(/signup, /login 등)는 각자 SecurityConfig 에서 override.
-                .authorizeHttpRequests(authorize -> authorize
-                        // K8s probe (liveness/readiness) 와 Prometheus scrape 가 인증 없이 접근.
-                        // /actuator/health/** 와일드카드로 /actuator/health/liveness, /readiness 등 포함.
-                        .requestMatchers("/actuator/health/**", "/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
-                        // Swagger / OpenAPI — 외부 노출은 api-gateway 에서 ADMIN role 로 보호.
-                        // 각 서비스의 /v3/api-docs/** 는 api-gateway 가 cluster 내부에서 fetch (aggregation).
-                        // /swagger-ui/** 는 서비스 직접 접근 시 dev 디버깅 용도.
-                        .requestMatchers("/v3/api-docs/**", "/v3/api-docs.yaml", "/swagger-ui/**", "/swagger-ui.html", "/swagger-resources/**", "/webjars/**").permitAll()
-                        .anyRequest().authenticated()
-                )
+                .authorizeHttpRequests(authorize -> {
+                    // K8s probe (liveness/readiness) 와 Prometheus scrape 가 인증 없이 접근.
+                    // /actuator/health/** 와일드카드로 /actuator/health/liveness, /readiness 등 포함.
+                    authorize.requestMatchers("/actuator/health/**", "/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll();
+                    // Swagger / OpenAPI 경로 — 소비 서비스가 trusta.swagger.expose-public=true 명시 시에만 permit.
+                    // 외부 노출 보호는 api-gateway 에서 ADMIN role 로 (서비스 직접 노출 환경에선 false 유지).
+                    if (exposeSwaggerPublic) {
+                        authorize.requestMatchers(
+                                "/v3/api-docs/**", "/v3/api-docs.yaml",
+                                "/swagger-ui/**", "/swagger-ui.html",
+                                "/swagger-resources/**", "/webjars/**"
+                        ).permitAll();
+                    }
+                    authorize.anyRequest().authenticated();
+                })
                 .exceptionHandling(c -> {
                     c.authenticationEntryPoint(authenticationEntryPoint);
                     c.accessDeniedHandler(accessDeniedHandler);


### PR DESCRIPTION
## 🌱 설명

common 라이브러리에 springdoc 기반 OpenAPI 자동 설정 추가. 각 도메인 서비스가 common 0.4.0 받으면 `/v3/api-docs`, `/swagger-ui` 가 자동 활성화.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

- SwaggerConfig 신규 — OpenAPI 메타 + JWT Bearer SecurityScheme (Keycloak access_token 호환)
- CommonAutoConfiguration 의 @Import 에 SwaggerConfig 등록
- SecurityConfig 에 /v3/api-docs/**, /swagger-ui/** permitAll — 외부 노출 보호는 api-gateway 에서 ADMIN role 로
- springdoc-openapi-starter-webmvc-ui:2.7.0 추가 (servlet MVC 기반)
- version 0.4.0-SNAPSHOT 으로 bump

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- api-gateway 의 aggregation + ADMIN role 보호는 후속 PR (이 PR 머지 + common 0.4.0 publish 가 선행 필요).
- 각 도메인 서비스의 build.gradle 의 common 버전 bump 도 후속 작업.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive Swagger/OpenAPI documentation UI to the application
  * API endpoints are now fully documented and explorable through a dedicated web interface

* **Chores**
  * Project version updated to 0.4.0-SNAPSHOT
  * Added OpenAPI UI dependency to enable API documentation support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/common/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->